### PR TITLE
Update cyclonedx-cli to v0.25.0

### DIFF
--- a/Formula/cyclonedx-cli.rb
+++ b/Formula/cyclonedx-cli.rb
@@ -1,21 +1,21 @@
 class CyclonedxCli < Formula
   desc "CycloneDX CLI tool for SBOM analysis, merging, diffs and format conversions."
   homepage "https://cyclonedx.org"
-  version "0.24.2"
+  version "0.25.0"
   license "Apache-2.0"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-osx-x64", :using => :nounzip
-      sha256 "567f11d59fcfb6c9462f6dc4556c3bc06938d06ad9bc99425cd301693ab57d70"
+      url "https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.25.0/cyclonedx-osx-x64", :using => :nounzip
+      sha256 "83ba4871298db3123dbea23f425cf23316827abcdaded16824b925f1bc69446d"
 
       def install
         bin.install "cyclonedx-osx-x64" => "cyclonedx"
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-osx-arm64"
-      sha256 "a1697e85b1aef616dfd0cf62283b50cd7cbe4edbcd638dddba0c2189bbf5cd7a"
+      url "https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.25.0/cyclonedx-osx-arm64"
+      sha256 "826c21a2ad146e0542c22fa3bf31f4a744890d89052d597c4461ec6e2302ff2d"
 
       def install
         bin.install "cyclonedx-osx-arm64" => "cyclonedx"
@@ -25,24 +25,24 @@ class CyclonedxCli < Formula
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-arm64", :using => :nounzip
-      sha256 "e781d32266ec89cb2c477f27c399f022f420db2e2b595818087e1d5bccbff9d4"
+      url "https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.25.0/cyclonedx-linux-arm64", :using => :nounzip
+      sha256 "eaac307ca4d7f3ee2a10e5fe898d7ff16c4b8054b10cc210abe6f6d703d17852"
 
       def install
         bin.install "cyclonedx-linux-arm64" => "cyclonedx"
       end
     end
     if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
-      url "https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-arm", :using => :nounzip
-      sha256 "58fa5f25c7cb522ad6883da539de6213218208cd1263ff675291ebe6c6770165"
+      url "https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.25.0/cyclonedx-linux-arm", :using => :nounzip
+      sha256 "d094e59f74bca280e8b3521512fb99d0af5d8d0dcd85a78164fa12abaf405ec0"
 
       def install
         bin.install "cyclonedx-linux-arm" => "cyclonedx"
       end
     end
     if Hardware::CPU.intel?
-      url "https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.24.2/cyclonedx-linux-x64", :using => :nounzip
-      sha256 "ef0d3b31d176e02bc594f83e19cfcea053c6bc5b197351f71696e189390f851d"
+      url "https://github.com/CycloneDX/cyclonedx-cli/releases/download/v0.25.0/cyclonedx-linux-x64", :using => :nounzip
+      sha256 "bd26ccba454cc9f12b6860136e1b14117b829a5f27e993607ff526262c5a7ff0"
 
       def install
         bin.install "cyclonedx-linux-x64" => "cyclonedx"


### PR DESCRIPTION
Included the latest binaries and checksums.

Closes: https://github.com/CycloneDX/homebrew-cyclonedx/issues/5.